### PR TITLE
feat: adds PR comments/commits data, fixes queryFilters tests

### DIFF
--- a/fixtures/getAllWorkResponse.fixture.json
+++ b/fixtures/getAllWorkResponse.fixture.json
@@ -6248,7 +6248,7 @@
                       "pushedDate": "2022-04-19T17:33:23Z",
                       "author": {
                         "user": {
-                          "login": "chiedo"
+                          "login": "inkblotty"
                         }
                       },
                       "associatedPullRequests": {
@@ -6257,7 +6257,7 @@
                             "title": "Update hww.yml",
                             "url": "https://github.com/github/accessibility/pull/1049",
                             "author": {
-                              "login": "chiedo"
+                              "login": "inkblotty"
                             }
                           }
                         ]
@@ -6275,7 +6275,7 @@
                       "title": "Update hww.yml",
                       "url": "https://github.com/github/accessibility/pull/1049",
                       "author": {
-                        "login": "chiedo"
+                        "login": "inkblotty"
                       }
                     },
                     "comments": {

--- a/fixtures/getAllWorkResponse.fixture.json
+++ b/fixtures/getAllWorkResponse.fixture.json
@@ -6366,7 +6366,7 @@
                       "pushedDate": "2022-04-19T01:23:07Z",
                       "author": {
                         "user": {
-                          "login": "howie-work[bot]"
+                          "login": "inkblotty"
                         }
                       },
                       "associatedPullRequests": {
@@ -6388,7 +6388,7 @@
                       "pushedDate": "2022-04-19T01:23:33Z",
                       "author": {
                         "user": {
-                          "login": "chiedo"
+                          "login": "inkblotty"
                         }
                       },
                       "associatedPullRequests": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf ./lib/* && tsc",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/src/queries.test.ts
+++ b/src/queries.test.ts
@@ -19,7 +19,7 @@ describe('getAllWorkForRespository', () => {
         expect(result.issueComments.data.length).toEqual(52);
 
         expect(result.prsCreated.data.length).toEqual(16);
-        expect(result.prCommits.data.length).toEqual(1);
+        expect(result.prCommits.data.length).toEqual(2);
         expect(result.prComments.data.length).toEqual(3);
     });
 });

--- a/src/queries.test.ts
+++ b/src/queries.test.ts
@@ -20,5 +20,6 @@ describe('getAllWorkForRespository', () => {
 
         expect(result.prsCreated.data.length).toEqual(16);
         expect(result.prCommits.data.length).toEqual(1);
+        expect(result.prComments.data.length).toEqual(3);
     });
 });

--- a/src/queries.test.ts
+++ b/src/queries.test.ts
@@ -19,6 +19,6 @@ describe('getAllWorkForRespository', () => {
         expect(result.issueComments.data.length).toEqual(52);
 
         expect(result.prsCreated.data.length).toEqual(16);
-        console.log('results', result.prsCreated.data.length);
+        expect(result.prCommits.data.length).toEqual(1);
     });
 });

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -144,6 +144,17 @@ export const getAllWorkForRepository = async (requestOwner: string, repoName: st
 
     // TODO: Do we only want to return commits to PRs that the original user did NOT create?
     const commitsToPRs = filterCreatedThingByAuthorAndCreation(flattenedPRCommits, username, sinceIso);
+
+    const filterCommentsFromOtherUserOnPR = (currentUser: String, reviews) => {
+      const filterOtherAuthors = reviews.filter(review => review.pullRequest.author.login !== currentUser);
+      const comments = filterOtherAuthors.map(item => item.comments.nodes).flat();
+
+      return comments;
+    }
+
+    // Comments on PRs by another user
+    const commentsOnOthersPRs = filterCommentsFromOtherUserOnPR(username,  prReviewsAndCommits.edges.map(edge => edge.node.reviews.nodes).flat());
+
     const createdPRs = prsCreated.edges.map(edge => edge.node);
     const createdIssues = repository.issues.nodes;
     const issueComments = filterCommentsByUser(flattenedIssueComments, username);
@@ -181,10 +192,10 @@ export const getAllWorkForRepository = async (requestOwner: string, repoName: st
             data: commitsToPRs,
             type: QueryType['pr-commit']
         },
-        // prComments: {
-        //     repo: repoName,
-        //     data: commentsOnOthersPRs,
-        //     type: QueryType['pr-comment-created']
-        // },
+        prComments: {
+            repo: repoName,
+            data: commentsOnOthersPRs,
+            type: QueryType['pr-comment-created']
+        },
     }
 }

--- a/src/queryFilters.test.ts
+++ b/src/queryFilters.test.ts
@@ -25,6 +25,22 @@ const testArr = [
         html_url: 'https://github.com/somewhere/bloop/pull/3'
     }
 ];
+
+const testReviewCommentArr = [
+    {
+        author: { login: username },
+        html_url: 'https://github.com/somewhere/bloop/pull/1'
+    },
+    {
+        author: { login: 'someone-else' },
+        html_url: 'https://github.com/somewhere/bloop/pull/2'
+    },
+    {
+        author: { login: username },
+        html_url: 'https://github.com/somewhere/bloop/pull/3'
+    }
+];
+
 describe('queryFilters', () => {
     test('filterPRsByAuthorAndCreation', () => {
         const result = filterPRsByAuthorAndCreation(testArr, username, lastWeek.toISOString());
@@ -35,16 +51,16 @@ describe('queryFilters', () => {
 
     describe('filterCommentsByUser', () => {
         test('include single user', () => {
-            const result = filterCommentsByUser(testArr, username);
+            const result = filterCommentsByUser(testReviewCommentArr, username);
             expect(result.length).toEqual(2);
-            expect(result[0].user.login).toEqual(username);
-            expect(result[1].user.login).toEqual(username);
+            expect(result[0].author.login).toEqual(username);
+            expect(result[1].author.login).toEqual(username);
         });
 
         test('exclude single user', () => {
-            const result = filterCommentsByUser(testArr, username, true);
+            const result = filterCommentsByUser(testReviewCommentArr, username, true);
             expect(result.length).toEqual(1);
-            expect(result[0].user.login).toEqual('someone-else');
+            expect(result[0].author.login).toEqual('someone-else');
         })
     });
 });

--- a/src/queryFilters.ts
+++ b/src/queryFilters.ts
@@ -4,18 +4,23 @@ export const getIsWithinRange = (date1: string, date2: string): boolean => {
 
 interface CreatedThing {
     author?: {
+      login?: string;
+      user?: {
         login: string;
+      }
     };
     created_at?: string;
     createdAt?: string;
+    pushedDate?: string;
     user?: {
         login: string;
     };
 }
 export const filterCreatedThingByAuthorAndCreation = (list: CreatedThing[], username: string, sinceIso, excludeUser?: boolean) => {
     return list.filter(thing => {
-        const isWithinRange = getIsWithinRange(thing.createdAt, sinceIso);
-        const userField = thing.author?.login;
+        const createdDate = thing?.createdAt || thing?.pushedDate;
+        const isWithinRange = getIsWithinRange(createdDate, sinceIso);
+        const userField = thing.author?.user?.login || thing.author?.login;
         const isAuthoredByUsername = excludeUser ? userField !== username : userField === username;
         return isAuthoredByUsername && isWithinRange;
     })

--- a/src/queryFilters.ts
+++ b/src/queryFilters.ts
@@ -53,3 +53,26 @@ interface ReviewComment {
 export const filterCommentsByUser = (commentsArr: ReviewComment[], username: string, excludeUser?: boolean): ReviewComment[] => {
     return commentsArr.filter(({ author }) => excludeUser ? author.login !== username : author.login === username);
 }
+
+// TODO: Refactor; can we use one of the existing filters instead?
+// TODO: Add proper types and tests
+export const filterCommitsFromOtherUserOnPR = (currentUser: String, commits) => {
+  const filterPRsByOtherAuthors = commits.filter(commit => {
+      const [filteredPRs] = commit.commit.associatedPullRequests.nodes.filter(node => !node.author.login.includes(currentUser));
+
+    return filteredPRs
+  });
+
+  const filterCommitsByCurrentUser = filterPRsByOtherAuthors.filter(pr => pr.commit.author.user.login.includes(currentUser))
+
+  return filterCommitsByCurrentUser;
+}
+
+// TODO: Refactor; can we use one of the existing filters instead?
+// TODO: Add proper types and tests
+export const filterCommentsFromOtherUserOnPR = (currentUser: String, reviews) => {
+  const filterOtherAuthors = reviews.filter(review => review.pullRequest.author.login !== currentUser);
+  const comments = filterOtherAuthors.map(item => item.comments.nodes).flat();
+
+  return comments;
+}


### PR DESCRIPTION
* Fixes `queryFilters` tests to match new structure
* Captures PR commits made on _someone else's_ PR
* Captures PR review comments made on _someone else's_ PR

TODOs left as comments, could use some refactor, proper typing, and tests. There may be a way to reuse or combine some of the existing filters.