### PR TITLE
feat: opens PR as draft

### DIFF
--- a/src/openPR.ts
+++ b/src/openPR.ts
@@ -11,6 +11,7 @@ const openPR = async ({ owner, repo }: InputFields, username: string, branchName
         base: 'main',
         head: `refs/heads/${branchName}`,
         title: `@${username}'s Work: ${now}`,
+        draft: true,
         body, 
         headers: {
             authorization: `token ${process.env.GH_TOKEN}`


### PR DESCRIPTION
this will give ICs time to review their work before the FR merges

tests passed, and I'm doing a bit of a cowboy PR here not testing it, but the [create PR docs](https://octokit.github.io/rest.js/v18#pulls-create) don't even indicate expected type information and I'm thinking we can test "in production" easier than I can set up a dev env.