### PR TITLE
remove forEach to fix secondary rate limiting issues

### DIFF
--- a/src/groupIssues.ts
+++ b/src/groupIssues.ts
@@ -13,7 +13,8 @@ const handleIssueGroups = (allIssuesCreated: QueryGroup[], allIssueComments: Que
         }
     };
 
-    allIssuesCreated.forEach(repoGroup => {
+    for (const repoGroup of allIssuesCreated) {
+    
         const { data, type } = repoGroup;
         if (type === QueryType['issue-created'] && data[0]) {
             const [repoUrl] = data[0].url.split('/issues');
@@ -27,10 +28,10 @@ const handleIssueGroups = (allIssuesCreated: QueryGroup[], allIssueComments: Que
                 }))
             }
         }
-    });
+    };
 
-    allIssueComments.forEach(repoGroup => {
-        repoGroup.data.forEach(comment => {
+    for (const repoGroup of allIssueComments) {
+        for (const comment of repoGroup.data) {
             // use the specific PR as key
             const key = comment.url.split('#')[0];
             const issueUrl = key.split('github.com')[1];
@@ -54,8 +55,8 @@ const handleIssueGroups = (allIssuesCreated: QueryGroup[], allIssueComments: Que
                 title: `Comment #${finalIssues.secondary[issueUrl].artifacts.length + 1}`,
                 url: comment.url,
             });
-        })
-    });
+        }
+    };
     return finalIssues as OutputGroupGroup;
 }
 export default handleIssueGroups;

--- a/src/groupPRs.ts
+++ b/src/groupPRs.ts
@@ -14,7 +14,7 @@ const handlePRGroups = (allPRsCreated: QueryGroup[], allPRComments: QueryGroup[]
         }
     };
 
-    allPRsCreated.forEach(repoGroup => {
+    for (const repoGroup of allPRsCreated) {
         const { data } = repoGroup;
         if (data[0]) {
             const [repoUrl] = data[0].url.split('/pull');
@@ -28,13 +28,13 @@ const handlePRGroups = (allPRsCreated: QueryGroup[], allPRComments: QueryGroup[]
                 }))
             }
         }
-    });
+    }
 
-    allPRCommits.forEach(repoGroup => {
+    for (const repoGroup of allPRCommits) {
         const { data } = repoGroup;
         const tempSecondary: OutputGroup = {}
         if (data[0]) {
-            data.forEach(({ commit }) => {
+            for (const commit of data) {
                 const [firstPR] = commit.associatedPullRequests.nodes;
                 const prAuthor = firstPR.author.user;
                 const prUrl = firstPR.url;
@@ -49,19 +49,19 @@ const handlePRGroups = (allPRsCreated: QueryGroup[], allPRComments: QueryGroup[]
                     title: `Commit at ${formatDateTime(new Date(commit.pushedDate))}`,
                     url: commit.url,
                 });
-            });
+            };
         }
 
-        Object.entries(tempSecondary).forEach(([prUrl, value]) => {
+        for (const [prUrl, value] of tempSecondary) {
             finalPRs.secondary[prUrl] = {
                 groupTitle: value.groupTitle.replace('<data.length>', `${value.artifacts.length}`),
                 artifacts: value.artifacts,
             }
-        });
-    });
+        };
+    };
 
-    allPRComments.forEach(repoGroup => {
-        repoGroup.data.forEach(comment => {
+    for (const repoGroup of allPRComments) {
+        for (const comment of repoGroup.data) {
             // use the specific PR as key
             const key = comment.url.split('#')[0];
             const prUrl = key.split('github.com')[1];
@@ -85,8 +85,8 @@ const handlePRGroups = (allPRsCreated: QueryGroup[], allPRComments: QueryGroup[]
                 title: `#${finalPRs.secondary[prUrl].artifacts.length + 1}`,
                 url: comment.url,
             });
-        })
-    });
+        }
+    };
 
     return finalPRs;
 }

--- a/src/handleInputAndAggregate.ts
+++ b/src/handleInputAndAggregate.ts
@@ -21,14 +21,14 @@ export const makeValidatedInput = (GH_TOKEN: string) => {
         usernames: '',
     };
     const requiredInputs = ["owner", "repo", "queried_repos", "secondary_prs_label", "usernames"];
-    requiredInputs.forEach(inputName => {
+    for (const inputName of requiredInputs) {
         const workflowValue = core.getInput(inputName, { required: true });
         if (!workflowValue) {
             throw new Error(makeRequiredErrorMessage(inputName));
         }
 
         endObj[inputName] = workflowValue;
-    });
+    };
 
     return endObj;
 }

--- a/src/makeGroupsIntoMarkdown.ts
+++ b/src/makeGroupsIntoMarkdown.ts
@@ -18,37 +18,52 @@ const makeGroupsIntoMarkdown = (groupGroups: OutputGroupGroup[], username: strin
         '## Unknown Work\n\n'
     ];
 
-    groupGroups.forEach(groups => {
-        Object.values(groups.primary).forEach(primaryVal => {
+    for (const groups of groupGroups) {
+        for (const primaryVal of Object.values(groups.primary)) {
             primaryArr.push(`### ${primaryVal.groupTitle}\n`);
-            primaryVal.artifacts.forEach(lineItem => primaryArr.push(`- [${lineItem.title}](${lineItem.url})\n`))
-        });
+
+        for (const lineItem of primaryVal.artifacts) {
+            primaryArr.push(`- [${lineItem.title}](${lineItem.url})\n`)
+        }
+           
+        };
     
-        Object.values(groups.secondary).forEach(secondaryVal => {
+        for (const secondaryVal of Object.values(groups.secondary)) {
             secondaryArr.push(`### ${secondaryVal.groupTitle}\n`);
-            secondaryVal.artifacts.forEach(lineItem => secondaryArr.push(`- [${lineItem.title}](${lineItem.url})\n`))
-        });
+            for (const lineItem of secondaryVal.artifacts) { d
+                secondaryArr.push(`- [${lineItem.title}](${lineItem.url})\n`)
+            }
+        };
     
-        Object.values(groups.unknown).forEach(unknownVal => {
+        for (const unknownVal of Object.values(groups.unknown)) {
             unknownArr.push(`### ${unknownVal.groupTitle}\n`);
-            unknownVal.artifacts.forEach(lineItem => unknownArr.push(`- [${lineItem.title}](${lineItem.url})\n`))
-        });
-    })
+            for (const lineItem of unknownVal.artifacts) {
+                unknownArr.push(`- [${lineItem.title}](${lineItem.url})\n`)
+            }
+        };
+    }
 
     if (primaryArr.length === 1) {
         primaryArr.push(noWorkMessage);
     }
-    primaryArr.forEach(item => markdownBodyArr.push(item));
+    for (const item of primaryArr) {
+        markdownBodyArr.push(item)
+    }
+   
     markdownBodyArr.push('\n');
 
     if (secondaryArr.length === 1) {
         secondaryArr.push(noWorkMessage);
     }
-    secondaryArr.forEach(item => markdownBodyArr.push(item));
+    for (const item of secondaryArr) {
+        markdownBodyArr.push(item)
+    }
     markdownBodyArr.push('\n');
 
     if (unknownArr.length !== 1) {
-        unknownArr.forEach(item => markdownBodyArr.push(item));
+        for (const item of unknownArr) {
+            markdownBodyArr.push(item)
+        }
     }
 
     return markdownBodyArr.join('');


### PR DESCRIPTION
### What

Attempting to follow [github action's best practices](https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits). 

Specifically limiting concurrency:
> Make requests for a single user or client ID serially. Do not make requests for a single user or client ID concurrently.
