### PR TITLE
add assignee to newly created PR

### DIFF
--- a/src/openPR.ts
+++ b/src/openPR.ts
@@ -5,6 +5,8 @@ import { InputFields } from "./shared.types";
 const openPR = async ({ owner, repo }: InputFields, username: string, branchName: string, body: string, destinationBranch: string): Promise<{ html_url: string }> => {
     const now = formatDate(new Date());
     const requestOwner = repo.includes('/') ? repo.split('/')[0] : owner;
+    const octokit = github.getOctokit(process.env.GH_TOKEN);
+
     const prData = {
         owner: requestOwner,
         repo,
@@ -17,7 +19,21 @@ const openPR = async ({ owner, repo }: InputFields, username: string, branchName
             authorization: `token ${process.env.GH_TOKEN}`
         },
     };
-    const { data } = await github.getOctokit(process.env.GH_TOKEN).request('POST /repos/{owner}/{repo}/pulls', prData);
+    const { data } = await octokit.request('POST /repos/{owner}/{repo}/pulls', prData);
+
+    const assigneeData = {
+        owner: requestOwner,
+        repo,
+        issue_number: data.number,
+        assignees: [
+            username
+        ],
+        headers: {
+            authorization: `token ${process.env.GH_TOKEN}`
+        }
+    }
+    octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', assigneeData)
+
     return { html_url: data.html_url };
 }
 export default openPR;


### PR DESCRIPTION
## Context

Closes https://github.com/inkblotty/my-work-action/issues/39

## Changes

This PR updates the my work action to assign the given user to the newly created pull request. Previously, the pull request was created without an assignee. Now the "subject" of the pull request (the person behind the "my" in "my work" 😄) will automatically be assigned to the pull request immediately after it's created.

## Approach

The existing code uses Octokit.js to create the pull request, so I did the same to add an assignee. I see elsewhere in the codebase that we use graphql to mutate data, so I could've used that instead of octokit here as well. But I thought it was better to be consistent with the existing code.


## TODO

- [ ] Test[^1]

[^1]: It seems like most of the existing files that mutate data via GitHub's public APIs are untested (ex. `openBranch.ts`, `commitToBranch.ts`), so I'm not sure it's worth investing the time in adding an e2e or integration test for these operations. However, I do want to at least manually test the changes to make sure they're behaving as expected, so I'll give this a spin on the command line and report back.