### PR TITLE
Add URI scheme and domain to issue url

### DIFF
--- a/src/groupIssues.ts
+++ b/src/groupIssues.ts
@@ -48,7 +48,7 @@ const handleIssueGroups = (allIssuesCreated: QueryGroup[], allIssueComments: Que
             // make sure that comment belongs to a PR group
             if (!finalIssues.secondary[issueUrl]) {
                 finalIssues.secondary[issueUrl] = {
-                    groupTitle: `Left comments on issue: [${comment.issue.title}](${issueUrl}) in ${repoGroup.repo}`,
+                    groupTitle: `Left comments on issue: [${comment.issue.title}](https://github.com${issueUrl}) in ${repoGroup.repo}`,
                     itemType: 'IssueComment',
                     artifacts: [],
                 }


### PR DESCRIPTION
The link to the issue (as the group title for comments) is incorrect.  Instead of having the full URL, it has the structure `/<ORG>/<REPO>/issues/<ISSUE_NUMBER>`.  Clicking it (at least in Arc) results in a 404.